### PR TITLE
Changed churchill repo to master from name changes

### DIFF
--- a/puppet/setup.pp
+++ b/puppet/setup.pp
@@ -19,7 +19,7 @@ vcsrepo { '/home/node-user/churchill':
     ensure   => present,
     provider => git,
     source   => 'https://github.com/psu-capstone/churchill.git',
-    revision => 'ryan_prelim',
+    revision => 'master',
     owner    => 'node-user',
     group    => 'node-user',
 }


### PR DESCRIPTION
Pulls from master now that we've agreed to use Ryan's code as a skeleton and old branch name no longer exists.
