### PR TITLE
Clone churchill repo to shared folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.*swp
 .vagrant
 vagrant_server.sh
+churchill

--- a/puppet/modules/churchill-node/files/upstart.conf
+++ b/puppet/modules/churchill-node/files/upstart.conf
@@ -8,4 +8,4 @@ respawn
 respawn limit 99 5
 
 chdir /home/node-user/churchill
-exec npm start
+exec su -c "npm start" node-user

--- a/puppet/users.pp
+++ b/puppet/users.pp
@@ -1,4 +1,4 @@
 ssh-user { "admin":
     username    => "admin",
-    pub_key => "puppet:///modules/users/authorized_keys",
+    pub_key     => "puppet:///modules/users/authorized_keys",
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,13 +12,13 @@ puppet module install puppetlabs-vcsrepo
 # copy local modules into puppet modules
 cp -r /vagrant/puppet/modules/* /etc/puppet/modules
 
-# apply puppet configuration locally
-puppet apply /vagrant/puppet/setup.pp
-
 # create admin user and apply add everyones public keys
 # to its ssh authorized_keys file
 puppet apply /vagrant/puppet/users.pp
 adduser admin sudo
+
+# apply puppet configuration locally
+puppet apply /vagrant/puppet/setup.pp
 
 # prevent admin user from needing a password for sudo commands
 echo "admin  ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers


### PR DESCRIPTION
Modify `puppet/setup.pp` script to clone churchill into the vagrant shared folder. On your host machine this is the folder containing the `Vagrantfile`.
- The churchill repo will be in `/vagrant/churchill` on the vm.
- A symlink is created from  `/vagrant/churchill` to `/home/node-user/churchill` so the churchill-node service has access.

This will allow people to make modifications using local development tools while the code is still running in the vm.
